### PR TITLE
updated Readme to show screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ extensions:
 # Repo Report
 **Repo Report** is an Outlook add-in, made with Angular, that scans your emails for public GitHub repository links and displays information about the ones it finds.
 
-![Repo Report screenshot](./repo report screenshot.PNG)
+![Repo Report screenshot](./repo%20report%20screenshot.PNG)
 
 ## Prerequisites
 * [npm](https://www.npmjs.com/), Node Package Manager, is required to install dev dependencies.


### PR DESCRIPTION
Since the screenshot image name contained space, it wasn't visible. It showed up as text. So I added %20 to display image instead